### PR TITLE
Update PHP_CodeSniffer repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Première *configuration* : aller dans **Tableau de bord>État d'Amapress** : ht
 * [Yalinqo](https://github.com/Athari/YaLinqo)
 * [PHP Imap](https://github.com/barbushin/php-imap) -  : utilisé pour la gestion des Emails groupés
 * [Faker](https://github.com/fzaninotto/Faker) -  : utilisé pour l'anonymisation des sites de démonstration
-* [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer)/[WPCS]()
+* [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer)/[WPCS]()
 * [Select2](https://github.com/select2/select2) - : utilisé pour les listes déroulantes
 * [FullCalendar](https://github.com/fullcalendar/fullcalendar) - : utilisé pour l'affichage en calendrier classique
 * [Slick](https://github.com/kenwheeler/slick) - : utilisé pour l'affichage du calendrier graphique

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,8 +9,8 @@
     <exclude-pattern>/node_modules/</exclude-pattern>
 
     <!-- How to scan -->
-    <!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
-    <!-- Annotated ruleset: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+    <!-- Usage instructions: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage -->
+    <!-- Annotated ruleset: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
     <arg value="sp"/> <!-- Show sniff and progress -->
     <arg name="basepath" value="./"/><!-- Strip the file paths down to the relevant bit -->
     <arg name="colors"/>


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932